### PR TITLE
Add check for this.summary_stats

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -598,7 +598,11 @@ class PipelineSampleReads extends React.Component {
 
     let pipeline_run = null;
     const BLANK_TEXT = "unknown";
-    if (this.pipelineRun && this.pipelineRun.total_reads) {
+    if (
+      this.pipelineRun &&
+      this.pipelineRun.total_reads &&
+      this.summary_stats
+    ) {
       pipeline_run = (
         <div className="data">
           <div className="row">


### PR DESCRIPTION
- Add a check for this.summary_stats so that it doesn't null out in this.summary_stats.* conditionals on some failed reports
- The reports should have summary_stats anyway if they're showing this pipeline output section at all so this can go up here