### PR TITLE
parse_wdl_workflow.py: workarounds for new host filtering WDL

### DIFF
--- a/scripts/parse_wdl_workflow.py
+++ b/scripts/parse_wdl_workflow.py
@@ -149,6 +149,8 @@ def parse_input_item(reference):
         return parse_apply_expression(reference)
     elif isinstance(reference, WDL.Expr.Array):
         return parse_array_expression(reference)
+    elif isinstance(reference, (WDL.Expr.String, WDL.Expr.Int, WDL.Expr.Float, WDL.Expr.Boolean)):
+        return [] # ignore hard-coded constants
 
     raise Exception(f"Unsupported reference: {reference}")
 
@@ -180,7 +182,9 @@ def get_file_basenames(task_inputs):
     for task in task_inputs:
         # add parsing for globs
         output_name_mapping = [
-            (output.name, output.expr.parts[1]) for output in task.outputs if isinstance(output.type, WDL.Type.File)
+            (output.name, output.expr.parts[1])
+            for output in task.outputs
+            if isinstance(output.type, WDL.Type.File) and isinstance(output.expr, WDL.Expr.String)
         ]
         output_name_mapping.extend(
             [


### PR DESCRIPTION
@j-x-han @ovalenzuela19 @morsecodist @rzlim08 here are minimal changes to parse_wdl_workflow.py to make it work on the new host filtering WDL (mainly by just ignoring cases it didn't handle before). Forgive me I can't say I know how the output is used and whether therefore that's the right thing to do -- advice welcome of course....

Invocation:

```
scripts/parse_wdl_workflow.py < <(curl -sL https://raw.githubusercontent.com/chanzuckerberg/czid-workflows/mlin/modernize-host-filter/short-read-mngs/host_filter.wdl)
```