### PR TITLE
cache metrics reporting fix

### DIFF
--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -6,8 +6,11 @@
 unless Rails.env.test?
   require_all 'lib/metric_handlers'
 
-  # We were currently unable to find any cached_read.active_support, cached_write.active_support, and cache_fetch_hit.active_support
+  # We were currently unable to find any cache_read.active_support, cache_write.active_support, and cache_fetch_hit.active_support
   # events, but were left in to be able to be able to potentially find hidden cached events later and has low performance impact
+  ActiveSupport::Notifications.subscribe("cache_read.active_support", MetricHandlers::CacheReadMetricHandler.new)
+  ActiveSupport::Notifications.subscribe("cache_write.active_support", MetricHandlers::CacheWriteMetricHandler.new)
+  ActiveSupport::Notifications.subscribe("cache_fetch_hit.active_support", MetricHandlers::CacheFetchHitMetricHandler.new)
   ActiveSupport::Notifications.subscribe("process_action.action_controller", MetricHandlers::ActionControllerMetricHandler.new)
   ActiveSupport::Notifications.subscribe(/resque/, MetricHandlers::ResqueJobMetricHandler.new)
   ActiveSupport::Notifications.subscribe(/snippet/, MetricHandlers::SnippetMetricHandler.new)

--- a/lib/metric_handlers/cache_fetch_hit_metric_handler.rb
+++ b/lib/metric_handlers/cache_fetch_hit_metric_handler.rb
@@ -6,7 +6,7 @@ module MetricHandlers
       event_log = {
         type: "metric",
         source: "backend",
-        msg: "cached_fetch_hit.active_support",
+        msg: "cache_fetch_hit.active_support",
         v: 1,
         details: {
           name: event.name,

--- a/lib/metric_handlers/cache_read_metric_handler.rb
+++ b/lib/metric_handlers/cache_read_metric_handler.rb
@@ -6,7 +6,7 @@ module MetricHandlers
       event_log = {
         type: "metric",
         source: "backend",
-        msg: "cached_read.active_support",
+        msg: "cache_read.active_support",
         v: 1,
         details: {
           name: event.name,

--- a/lib/metric_handlers/cache_write_metric_handler.rb
+++ b/lib/metric_handlers/cache_write_metric_handler.rb
@@ -6,7 +6,7 @@ module MetricHandlers
       event_log = {
         type: "metric",
         source: "backend",
-        msg: "cached_write.active_support",
+        msg: "cache_write.active_support",
         v: 1,
         details: {
           name: event.name,


### PR DESCRIPTION
Hi folks!

Just a fix of the Active Instrumentation subscription to cache usage events, which apparently was the reason why there were no cache-related metrics.

`cache_*` not `cached_*` according to the [docs](https://guides.rubyonrails.org/active_support_instrumentation.html).